### PR TITLE
Adds push template support to Iterable client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-courier",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "package for interfacing with iterable's api",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/iterableClient.ts
+++ b/src/iterableClient.ts
@@ -47,6 +47,15 @@ export class IterableClient {
     return from(this.getTemplates(medium))
   }
 
+  async getPushTemplates(): Promise<PushTemplate[]> {
+    const response: AxiosResponse<{ templates: PushTemplate[] }> = await this.client.get('/templates?messageMedium=push')
+    return response.data.templates
+  }
+  // Observable based method
+  getPushTemplates$ = (): Observable<PushTemplate[]> => {
+    return from(this.getPushTemplates())
+  }
+
   async getTemplateById(
     templateType: string,
     templateId: number
@@ -62,6 +71,21 @@ export class IterableClient {
     templateId: number
   ): Observable<Template> => {
     return from(this.getTemplateById(templateType, templateId))
+  }
+
+  async getPushTemplateById(
+    templateId: number
+  ): Promise<PushTemplate> {
+    const response: AxiosResponse<PushTemplate> = await this.client.get(
+      `/templates/push/get?templateId=${templateId}`
+    )
+    return response.data
+  }
+  // Observable based method
+  getPushTemplatebyId$ = (
+    templateId: number
+  ): Observable<PushTemplate> => {
+    return from(this.getPushTemplateById(templateId))
   }
 
   async createTemplate(
@@ -94,6 +118,20 @@ export class IterableClient {
     templateType: string
   ): Observable<IterableTemplateResponse> => {
     return from(this.updateTemplate(data, templateType))
+  }
+
+  async updatePushTemplate(
+    data: PushTemplate
+  ): Promise<IterableTemplateResponse> {
+    const response: AxiosResponse<IterableTemplateResponse> =
+      await this.client.post(`/templates/push/update`, data)
+    return response.data
+  }
+  // Observable based method
+  updatePushTemplate$ = (
+    data: PushTemplate,
+  ): Observable<IterableTemplateResponse> => {
+    return from(this.updatePushTemplate(data))
   }
 
   async deleteTemplate(data: number[]) {

--- a/src/iterableClient.ts
+++ b/src/iterableClient.ts
@@ -2,21 +2,22 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import { Observable, from } from 'rxjs'
 import {
   Campaign,
-  cancelSMSBody,
+  CancelSMSBody,
   Channel,
-  iterableCampaignResponse,
-  iterableCreateCampaignBody,
-  iterableDeleteTemplateResponse,
-  iterableTemplateResponse,
-  iterableTriggerCampaignBody,
+  IterableCampaignResponse,
+  IterableCreateCampaignBody,
+  IterableDeleteTemplateResponse,
+  IterableTemplateResponse,
+  IterableTriggerCampaignBody,
   List,
   ListRemoveBody,
   ListResponse,
   ListSubBody,
   MessageType,
-  sendEmailBody,
-  sendSMSBody,
+  SendEmailBody,
+  SendSMSBody,
   Template,
+  PushTemplate,
 } from './iterableInterfaces'
 
 interface IterableOptions {
@@ -66,8 +67,8 @@ export class IterableClient {
   async createTemplate(
     data: Record<string, any>,
     templateType: string
-  ): Promise<iterableTemplateResponse> {
-    const response: AxiosResponse<iterableTemplateResponse> =
+  ): Promise<IterableTemplateResponse> {
+    const response: AxiosResponse<IterableTemplateResponse> =
       await this.client.post(`/templates/${templateType}/upsert`, data)
     return response.data
   }
@@ -75,15 +76,15 @@ export class IterableClient {
   createTemplate$ = (
     data: Record<string, any>,
     templateType: string
-  ): Observable<iterableTemplateResponse> => {
+  ): Observable<IterableTemplateResponse> => {
     return from(this.createTemplate(data, templateType))
   }
 
   async updateTemplate(
     data: Template,
     templateType: string
-  ): Promise<iterableTemplateResponse> {
-    const response: AxiosResponse<iterableTemplateResponse> =
+  ): Promise<IterableTemplateResponse> {
+    const response: AxiosResponse<IterableTemplateResponse> =
       await this.client.post(`/templates/${templateType}/update`, data)
     return response.data
   }
@@ -91,7 +92,7 @@ export class IterableClient {
   updateTemplate$ = (
     data: Template,
     templateType: string
-  ): Observable<iterableTemplateResponse> => {
+  ): Observable<IterableTemplateResponse> => {
     return from(this.updateTemplate(data, templateType))
   }
 
@@ -99,14 +100,14 @@ export class IterableClient {
     const constructedData = {
       ids: data,
     }
-    const response: AxiosResponse<iterableDeleteTemplateResponse> =
+    const response: AxiosResponse<IterableDeleteTemplateResponse> =
       await this.client.post('/templates/bulkDelete', constructedData)
     return response.data
   }
   // Observable based method
   deleteTemplate$ = (
     data: number[]
-  ): Observable<iterableDeleteTemplateResponse> => {
+  ): Observable<IterableDeleteTemplateResponse> => {
     return from(this.deleteTemplate(data))
   }
 
@@ -143,7 +144,7 @@ export class IterableClient {
     return from(this.getCampaignMetrics(campaignId))
   }
 
-  async createCampaign(data: iterableCreateCampaignBody): Promise<number> {
+  async createCampaign(data: IterableCreateCampaignBody): Promise<number> {
     const response: AxiosResponse<{ campaignId: number }> = await this.client.post(
       '/campaigns/create',
       data
@@ -151,7 +152,7 @@ export class IterableClient {
     return response.data.campaignId
   }
   // Observable based method
-  createCampaign$ = (data: iterableCreateCampaignBody): Observable<number> => {
+  createCampaign$ = (data: IterableCreateCampaignBody): Observable<number> => {
     return from(this.createCampaign(data))
   }
 
@@ -167,29 +168,29 @@ export class IterableClient {
     return from(this.archiveCampaigns(data))
   }
 
-  async activateTriggeredCampaign(data: Record<string, number>): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/campaigns/activateTriggered', data)
+  async activateTriggeredCampaign(data: Record<string, number>): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/campaigns/activateTriggered', data)
     return response.data
   }
   // Observable based method
-  activateTriggeredCampaign$ = (data: Record<string, number>): Observable<iterableCampaignResponse> => {
+  activateTriggeredCampaign$ = (data: Record<string, number>): Observable<IterableCampaignResponse> => {
     return from(this.activateTriggeredCampaign(data))
   }
 
-  async triggerCampaign(data: iterableTriggerCampaignBody): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/campaigns/trigger', data)
+  async triggerCampaign(data: IterableTriggerCampaignBody): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/campaigns/trigger', data)
     return response.data
   }
-  triggerCampaign$ = (data: iterableTriggerCampaignBody): Observable<iterableCampaignResponse> => {
+  triggerCampaign$ = (data: IterableTriggerCampaignBody): Observable<IterableCampaignResponse> => {
     return from(this.triggerCampaign(data))
   }
 
-  async deactivateTriggeredCampaign(data: Record<string, number>): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/campaigns/deactivateTriggered', data)
+  async deactivateTriggeredCampaign(data: Record<string, number>): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/campaigns/deactivateTriggered', data)
     return response.data
   }
   // Observable based method
-  deactivateTriggeredCampaign$ = (data: Record<string, number>): Observable<iterableCampaignResponse> => {
+  deactivateTriggeredCampaign$ = (data: Record<string, number>): Observable<IterableCampaignResponse> => {
     return from(this.deactivateTriggeredCampaign(data))
   }
 
@@ -252,41 +253,41 @@ export class IterableClient {
     return from(this.unsubUsersFromList(data))
   }
 
-  async deleteList(listId: number): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.delete(`/lists/${listId}`)
+  async deleteList(listId: number): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.delete(`/lists/${listId}`)
     return response.data
   }
   // Observable based method
-  deleteList$ = (listId: number): Observable<iterableCampaignResponse> => {
+  deleteList$ = (listId: number): Observable<IterableCampaignResponse> => {
     return from(this.deleteList(listId))
   }
 
   /* ==== EMAIL CALL ==== */
-  async sendEmailToAddress(data: sendEmailBody): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/email/target', data)
+  async sendEmailToAddress(data: SendEmailBody): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/email/target', data)
     return response.data
   }
   // Observable based method
-  sendEmailToAddress$ = (data: sendEmailBody): Observable<iterableCampaignResponse> => {
+  sendEmailToAddress$ = (data: SendEmailBody): Observable<IterableCampaignResponse> => {
     return from(this.sendEmailToAddress(data))
   }
 
   /* ==== SMS CALLS ==== */
-  async sendSMS(data: sendSMSBody): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/sms/target', data)
+  async sendSMS(data: SendSMSBody): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/sms/target', data)
     return response.data
   }
 
-  sendSMS$ = (data: sendSMSBody): Observable<iterableCampaignResponse> => {
+  sendSMS$ = (data: SendSMSBody): Observable<IterableCampaignResponse> => {
     return from(this.sendSMS(data))
   }
 
-  async cancelSMS(data: cancelSMSBody): Promise<iterableCampaignResponse> {
-    const response: AxiosResponse<iterableCampaignResponse> = await this.client.post('/sms/cancel', data)
+  async cancelSMS(data: CancelSMSBody): Promise<IterableCampaignResponse> {
+    const response: AxiosResponse<IterableCampaignResponse> = await this.client.post('/sms/cancel', data)
     return response.data
   }
 
-  cancelSMS$ = (data: cancelSMSBody): Observable<iterableCampaignResponse> => {
+  cancelSMS$ = (data: CancelSMSBody): Observable<IterableCampaignResponse> => {
     return from(this.cancelSMS(data))
   }
 }

--- a/src/iterableInterfaces.ts
+++ b/src/iterableInterfaces.ts
@@ -29,13 +29,13 @@ export interface Template {
   message?: string
 }
 
-export interface iterableTemplateResponse {
+export interface IterableTemplateResponse {
   msg: string
   code: string
   params?: string | null
 }
 
-export interface iterableDeleteTemplateResponse {
+export interface IterableDeleteTemplateResponse {
   success: number[]
   failed: number[]
   failureReason: string
@@ -77,7 +77,7 @@ export interface Campaign {
   type: string
   listIds?: number[]
 }
-export interface iterableCreateCampaignBody {
+export interface IterableCreateCampaignBody {
   name: string
   templateId: number
   listIds?: number[]
@@ -88,12 +88,12 @@ export interface iterableCreateCampaignBody {
   defaultTimeZone?: string
   startTimeZone?: string
 }
-export interface iterableCampaignResponse {
+export interface IterableCampaignResponse {
   msg: string
   code: string
   params: Record<string, any>
 }
-export interface iterableTriggerCampaignBody {
+export interface IterableTriggerCampaignBody {
   campaignId: number
   listIds: number[]
   dataFields?: Record<string, any>
@@ -131,7 +131,7 @@ export interface ListResponse {
 }
 
 /* ===== Email ===== */
-export interface sendEmailBody {
+export interface SendEmailBody {
   allowRepeatMarketingSends?: boolean
   campaignId: number
   dataFields?: Record<string, any>
@@ -141,7 +141,7 @@ export interface sendEmailBody {
 }
 
 /* ===== SMS ===== */
-export interface sendSMSBody {
+export interface SendSMSBody {
   allowRepeatMarketingSends?: boolean,
   campaignId: number,
   dataFields?: Record<string, any>,
@@ -150,10 +150,71 @@ export interface sendSMSBody {
   sendAt?: string
 }
 
-export interface cancelSMSBody {
+export interface CancelSMSBody {
   campaignId?: number,
   email?: string,
   scheduledMessageId?: number,
   userId?: string
+}
+
+/* ===== Native Push ===== */
+export interface Action {
+  data?: string;
+  type?: string;
+}
+
+export interface ActionIcon {
+  iconType?: Record<string, unknown>;
+  imageName?: string;
+}
+
+export interface Button {
+  action?: Action;
+  actionIcon?: ActionIcon;
+  buttonType?: string; // e.g. "default"
+  identifier?: string;
+  inputPlaceholder?: string;
+  inputTitle?: string;
+  openApp?: boolean;
+  requiresUnlock?: boolean;
+  title?: string;
+}
+
+export interface DeepLink {
+  android?: string;
+  ios?: string;
+}
+
+export interface RichMedia {
+  android?: string;
+  ios?: string;
+}
+
+export interface PushTemplate {
+  badge?: string;
+  buttons?: Button[];
+  cacheDataFeed?: boolean;
+  campaignDataFields?: Record<string, unknown>;
+  campaignId?: number | string | Record<string, unknown>;
+  clientTemplateId?: string;
+  createdAt?: string; // ISO timestamp
+  dataFeedIds?: number[];
+  deeplink?: DeepLink;
+  interruptionLevel?: string;
+  isDefaultLocale?: boolean;
+  isSilentPush?: boolean;
+  locale?: string;
+  mergeDataFeedContext?: boolean;
+  message?: string;
+  messageTypeId?: number;
+  name?: string;
+  payload?: Record<string, unknown>;
+  relevanceScore?: number;
+  richMedia?: RichMedia;
+  sound?: string;
+  templateId: number; // required
+  title?: string;
+  updatedAt?: string; // ISO timestamp
+  wake?: boolean;
 }
 


### PR DESCRIPTION
Adds support for managing push templates via the Iterable client, enabling retrieval, update, and observable-based access.

Key changes:
- Adds methods to list push templates and fetch a single push template by ID.
- Adds method to update push templates.
- Adds RxJS Observable wrappers for the new push template methods to match existing API style.
- Updates client typings to include push template types (as reflected by commit history).

Why:
- Enables programmatic management of push notification templates through the client library, matching existing support for other template mediums and providing both promise- and observable-based APIs for callers.

Notes:
- No breaking changes to existing template methods.
- Further type refinements were applied in separate commits.